### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ example
         denom_2 = "$.accounting[:].denomination",
         multiplier = "$.accounting[:].multiplier"
     )
-    w = s.where(
+    w = a.where(
         lambda sales_id, price_id: sales_id == price_id,
         lambda number: number > 0,
         lambda denom_1, denom_2 : denom_1 == denom_2


### PR DESCRIPTION
Small fix to the example that makes it clear how the chaining could work without intermediate variables.